### PR TITLE
Build script enhancements

### DIFF
--- a/build.py
+++ b/build.py
@@ -11,7 +11,7 @@ import shutil
 import multiprocessing
 
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 logging.basicConfig(level=logging.ERROR)
 
@@ -32,10 +32,10 @@ CMAKE_BUILD_FLAG_KEY = "cmake_build_flag"
 BUILD_DIR_FLAG_KEY = "cmake_build_dir"
 BUILD_DIR_CMAKE_FLAG_KEY = "cmake_build_dir_flag"
 
+# TODO SUPPORT ADDITION CMAKE ARGS PASSED IN BY USER
 # TODO PUT EACH CMD in array for debugging purposes(subprocess)
 # TODO ADD LINTING
 # TODO SUPPORT CORES FLAG
-# TODO SUPPORT ADDITION CMAKE ARGS PASSED IN BY USER
 # TODO SUPPORT MULTIPLE BUILDS(JSON)
 # TODO MAKE SOURCE DIR CONFIGURABLE
 
@@ -94,14 +94,12 @@ class CompilerType(enum.Enum):
     GNU = 0
     CLANG = 1
 
-    #TODO Tuple typing
     @staticmethod
-    def gnu_compiler_info():
+    def gnu_compiler_info() -> Tuple[str, str]:
         return tuple(CompilerType.which_gxx(), CompilerType.which_gcc())
 
-    #TODO Tuple typing
     @staticmethod
-    def clang_compiler_info():
+    def clang_compiler_info() -> Tuple[str, str]:
         return tuple(CompilerType.which_clangxx(), CompilerType.which_clang())
 
     @staticmethod

--- a/build.py
+++ b/build.py
@@ -258,7 +258,7 @@ def check_default_args(args_dict):
     return validated_args_dict
 
 
-def format_build_str(print_str: str, line_len: int = DEFAULT_LINE_WIDTH, fill_char: str = "#") -> None:
+def print_centered(print_str: str, line_len: int = DEFAULT_LINE_WIDTH, fill_char: str = "#") -> None:
     print(print_str.center(line_len, fill_char))
 
 
@@ -457,25 +457,25 @@ def run_cmake(cmake_lists_dir: str, cmake_build_commands: List[str], env_args: D
     # CMake source and build directory parameters
     # https://stackoverflow.com/questions/18826789/cmake-output-build-directory
     logging.debug(f"CMake {cmake_build_commands}")
-    format_build_str("CMAKE Config", fill_char="~")
+    print_centered("CMAKE Config", fill_char="~")
     subprocess_check_call(
         ["cmake"] + [f"-S{cmake_lists_dir}"] + cmake_build_commands, env=env_args)
-    format_build_str("CMAKE Config has completed successfully", fill_char="~")
+    print_centered("CMAKE Config has completed successfully", fill_char="~")
     print_new_line()
 
 
 def run_genhtml(coverage_file_url: str, report_out_dir: str) -> None:
-    format_build_str("Running genhtml", fill_char="~")
+    print_centered("Running genhtml", fill_char="~")
     subprocess_check_call(
         ["genhtml", coverage_file_url,  "--output-directory", report_out_dir])
-    format_build_str("LCOV has completed successfully", fill_char="~")
+    print_centered("LCOV has completed successfully", fill_char="~")
 
 
 def run_lcov(project_directory: str, build_dir: str, coverage_file_url: str, excludes_dirs: List[str] = COVERAGE_EXCLUDES_LIST) -> None:
-    format_build_str("Running LCOV", fill_char="~")
+    print_centered("Running LCOV", fill_char="~")
     subprocess_check_call(["lcov", "--capture", "--directory", build_dir, "--output-file",
                            coverage_file_url, "--no-external", "--base-directory", project_directory] + generate_lcov_excludes(excludes_dirs))
-    format_build_str("LCOV has completed successfully", fill_char="~")
+    print_centered("LCOV has completed successfully", fill_char="~")
 
 
 def run_git_info() -> None:
@@ -488,22 +488,22 @@ def run_git_info() -> None:
 
 def run_make(env_dict: Dict[str, str]):
     # https://stackoverflow.com/questions/7031126/switching-between-gcc-and-clang-llvm-using-cmake
-    format_build_str("Make", fill_char="~")
+    print_centered("Make", fill_char="~")
     subprocess_check_call(
         ["make", "-j", "{}".format(max(1, multiprocessing.cpu_count() - 2))], env=env_dict)
-    format_build_str("Make has completed successfully", fill_char="~")
+    print_centered("Make has completed successfully", fill_char="~")
     print_new_line()
 
 
 def run_make_clean(env_dict: Dict[str, str]):
-    format_build_str("Make Clean", fill_char="~")
+    print_centered("Make Clean", fill_char="~")
     subprocess_check_call(["make", "clean"], env=env_dict)
-    format_build_str("Make Clean has completed successfully", fill_char="~")
+    print_centered("Make Clean has completed successfully", fill_char="~")
     print_new_line()
 
 
 def run_tests():
-    format_build_str("Running Unit Tests", fill_char="-")
+    print_centered("Running Unit Tests", fill_char="-")
     subprocess_check_call(["ctest", "--verbose", "--stop-on-failure"])
 
 

--- a/tests/test_result_storage.cpp
+++ b/tests/test_result_storage.cpp
@@ -867,7 +867,7 @@ TEST_CASE("ResultStorage Non-Trivial multiple assignment [result][ResultStorage]
         {
             REQUIRE(initial_err.num_vec.size() == VEC_SIZE);
             std::for_each(initial_err.num_vec.begin(), initial_err.num_vec.end(),
-                          [m = initial_err.num_map, ref_vec = vec, ref_map = kv_map, count = 0](const auto& i) mutable {
+                          [m = initial_err.num_map, ref_vec = vec, ref_map = kv_map, count = 0ul](const auto& i) mutable {
                               REQUIRE(i == ref_vec[count]);
                               REQUIRE_FALSE(m.count(i) == 0);
                               REQUIRE(m[i] == ref_map[i]);
@@ -895,7 +895,7 @@ TEST_CASE("ResultStorage Non-Trivial multiple assignment [result][ResultStorage]
 
             REQUIRE(initial_err_chk.num_vec.size() == VEC_SIZE);
             std::for_each(initial_err_chk.num_vec.begin(), initial_err_chk.num_vec.end(),
-                          [m = initial_err.num_map, ref_vec = vec, ref_map = kv_map, count = 0](const auto& i) mutable {
+                          [m = initial_err.num_map, ref_vec = vec, ref_map = kv_map, count = 0ul](const auto& i) mutable {
                               REQUIRE(i == ref_vec[count]);
                               REQUIRE_FALSE(m.count(i) == 0);
                               REQUIRE(m[i] == ref_map[i]);
@@ -905,7 +905,7 @@ TEST_CASE("ResultStorage Non-Trivial multiple assignment [result][ResultStorage]
             REQUIRE(initial_storage_now_err.num_vec.size() == VEC_SIZE);
             std::for_each(initial_storage_now_err.num_vec.begin(), initial_storage_now_err.num_vec.end(),
                           [m = initial_storage_now_err.num_map, ref_vec = vec, ref_map = kv_map,
-                           count = 0](const auto& i) mutable {
+                           count = 0ul](const auto& i) mutable {
                               REQUIRE(i == ref_vec[count]);
                               REQUIRE_FALSE(m.count(i) == 0);
                               REQUIRE(m[i] == ref_map[i]);
@@ -953,7 +953,7 @@ TEST_CASE("ResultStorage Non-Trivial multiple assignment [result][ResultStorage]
             REQUIRE(initial_err_scope.num_vec.size() == VEC_SIZE);
             std::for_each(
                 initial_err_scope.num_vec.begin(), initial_err_scope.num_vec.end(),
-                [m = initial_err_scope.num_map, ref_vec = vec, ref_map = kv_map, count = 0](const auto& i) mutable {
+                [m = initial_err_scope.num_map, ref_vec = vec, ref_map = kv_map, count = 0ul](const auto& i) mutable {
                     REQUIRE(i == ref_vec[count]);
                     REQUIRE_FALSE(m.count(i) == 0);
                     REQUIRE(m[i] == ref_map[i]);


### PR DESCRIPTION
This allows for the build script to auto detect if the compiler is the same as previously used. If it is then it will continue on to build, if not then it will rebuild. This is achieved by looking at the `CMakeCache.txt` and then comparing if the passed in version is the same if so nothing is done if not the directory is wiped and freshly built.
Compiler change is set by a global env thus the harsh approach that is taken.